### PR TITLE
Fix coin reset on hit

### DIFF
--- a/gameLoop.js
+++ b/gameLoop.js
@@ -187,6 +187,7 @@ import {
         console.log("GameLoop: Reseteando estado por golpe con obstáculo.");
         state.resetCombo(); //
         state.setBoostActive(false); //
+        state.resetCoinCount(); // << NUEVO: Reiniciar todas las monedas recogidas
         state.setLevel(0); //
         state.resetAllPowerUps(); //
         obstaclesDodgedSinceLastHit = 0; // Resetear contador de esquivados


### PR DESCRIPTION
## Summary
- clear coin counts when resetting combo and level

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f40613bd883268670e04d56becc8c