### PR TITLE
Update obstacle visuals and shorten start time

### DIFF
--- a/config.js
+++ b/config.js
@@ -35,7 +35,8 @@ export const COIN_TYPES = Object.freeze({
   export const LEVEL_JUMP_MULTIPLIERS  = [1.0, 1.0,  1.1,  1.1,  1.2,  1.2];  // Ejemplo: Salto mejora en ciertos niveles
   
   /* ---------- Tiempo, puntuación, ranking ---------- */
-  export const INITIAL_TIME_S   = 120; // Tiempo inicial en segundos
+  // Tiempo inicial reducido para partidas más rápidas
+  export const INITIAL_TIME_S   = 30; // Tiempo inicial en segundos
   export const MAX_TIME_CAP_S   = INITIAL_TIME_S + 60; // Límite máximo de tiempo acumulable
   export const OBSTACLE_HIT_PENALTY_S = 1;  // Segundos penalización por golpe
   export const COIN_SCORE_MULTIPLIER  = 5;  // Puntos base por moneda (multiplicado por combo actual)

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <div id="player"></div>
 
         <div id="score">0</div>
-        <div id="timer">120.0</div>
+        <div id="timer">30.0</div>
         <div id="combo">Combo: 0</div>
 
         <div id="powerup-hud">

--- a/styles.css
+++ b/styles.css
@@ -233,14 +233,66 @@
   #player.collected { transform: scale(1.1); }
   
   /* --- Obstáculos --- */
-  .obstacle { width: 3.875%; height: 7.75%; background: var(--color-obstacle-bg); border: 4px solid var(--color-obstacle-border); box-shadow: 0 0 8px var(--color-obstacle-shadow), 0 0 15px var(--color-obstacle-shadow) inset; position: absolute; bottom: 0; z-index: 4; box-sizing: border-box; }
+  .obstacle {
+    width: 3.875%;
+    height: 7.75%;
+    background: radial-gradient(circle at center,
+              var(--color-obstacle-border) 0%,
+              var(--color-obstacle-bg) 70%);
+    border: 4px solid var(--color-obstacle-border);
+    border-radius: 4px;
+    box-shadow: 0 0 10px var(--color-obstacle-shadow),
+                0 0 20px var(--color-obstacle-shadow) inset;
+    position: absolute;
+    bottom: 0;
+    z-index: 4;
+    box-sizing: border-box;
+  }
   .obstacle.large { width: 4.625%; height: 9.25%; }
   .obstacle.square { /* Ya cubierto por .obstacle base */ }
-  .obstacle.triangle { width: 5%; height: 10%; clip-path: polygon(50% 0%, 100% 100%, 0% 100%); background: var(--color-obstacle-bg); border: 4px solid var(--color-obstacle-border); box-shadow: 0 0 8px var(--color-obstacle-shadow), 0 0 15px var(--color-obstacle-shadow) inset; position: absolute; bottom: 0; z-index: 4; box-sizing: border-box; }
-  .obstacle.cube { border-color: #8000ff; background: rgba(128,0,255,0.3); box-shadow: 0 0 8px #8000ff, 0 0 15px #8000ff inset; }
-  .obstacle.line { width: 3%; height: 14%; border-color: #ff7b00; background: rgba(255,123,0,0.3); box-shadow: 0 0 8px #ff7b00, 0 0 15px #ff7b00 inset; }
-  .obstacle.zeta { width: 6%; height: 7.75%; background: rgba(255,0,128,0.3); border: 4px solid #ff0080; box-shadow: 0 0 8px #ff0080, 0 0 15px #ff0080 inset; clip-path: polygon(0 0, 75% 0, 75% 50%, 100% 50%, 100% 100%, 25% 100%, 25% 50%, 0 50%); }
-  .obstacle.lshape { width: 6%; height: 7.75%; background: rgba(123,77,0,0.3); border: 4px solid #7b4d00; box-shadow: 0 0 8px #7b4d00, 0 0 15px #7b4d00 inset; clip-path: polygon(0 0, 50% 0, 50% 75%, 100% 75%, 100% 100%, 0 100%); }
+  .obstacle.triangle {
+    width: 5%;
+    height: 10%;
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+    background: radial-gradient(circle at center,
+              var(--color-obstacle-border) 0%,
+              var(--color-obstacle-bg) 70%);
+    border: 4px solid var(--color-obstacle-border);
+    box-shadow: 0 0 10px var(--color-obstacle-shadow),
+                0 0 20px var(--color-obstacle-shadow) inset;
+    position: absolute;
+    bottom: 0;
+    z-index: 4;
+    box-sizing: border-box;
+  }
+  .obstacle.cube {
+    border-color: #8000ff;
+    background: radial-gradient(circle at center, #8000ff 0%, rgba(128,0,255,0.3) 70%);
+    box-shadow: 0 0 10px #8000ff, 0 0 20px #8000ff inset;
+  }
+  .obstacle.line {
+    width: 3%;
+    height: 14%;
+    border-color: #ff7b00;
+    background: radial-gradient(circle at center, #ff7b00 0%, rgba(255,123,0,0.3) 70%);
+    box-shadow: 0 0 10px #ff7b00, 0 0 20px #ff7b00 inset;
+  }
+  .obstacle.zeta {
+    width: 6%;
+    height: 7.75%;
+    background: radial-gradient(circle at center, #ff0080 0%, rgba(255,0,128,0.3) 70%);
+    border: 4px solid #ff0080;
+    box-shadow: 0 0 10px #ff0080, 0 0 20px #ff0080 inset;
+    clip-path: polygon(0 0, 75% 0, 75% 50%, 100% 50%, 100% 100%, 25% 100%, 25% 50%, 0 50%);
+  }
+  .obstacle.lshape {
+    width: 6%;
+    height: 7.75%;
+    background: radial-gradient(circle at center, #7b4d00 0%, rgba(123,77,0,0.3) 70%);
+    border: 4px solid #7b4d00;
+    box-shadow: 0 0 10px #7b4d00, 0 0 20px #7b4d00 inset;
+    clip-path: polygon(0 0, 50% 0, 50% 75%, 100% 75%, 100% 100%, 0 100%);
+  }
   
   
   /* --- Monedas --- */


### PR DESCRIPTION
## Summary
- improve visual styling for obstacles with gradients and bigger glows
- reduce initial game time from 120s to 30s
- update timer in HTML to match

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f520d81648326bf4d431c605e4452