### PR TITLE
Fix dash activation via double tap

### DIFF
--- a/inputManager.js
+++ b/inputManager.js
@@ -32,7 +32,7 @@ export function initInputListeners() {
         // Saltar con Espacio durante el juego
         if (gameIsRunning && (e.code === 'Space' || e.key === ' ')) {
             e.preventDefault();
-            playerController.jump(gameIsRunning); //
+            playerController.manejarPulsacionEspacio(gameIsRunning); //
         }
         // Activar Dash con tecla 'C'
         else if (gameIsRunning && (e.code === 'KeyC' || e.key === 'c')) {
@@ -83,7 +83,7 @@ export function initInputListeners() {
     dom.container?.addEventListener('touchstart', (e) => { //
         const gameIsRunning = state.isGameRunning(); //
         if (gameIsRunning && !e.target.closest('button, a, input, .modal, #powerup-hud .hud-icon')) {
-            playerController.jump(gameIsRunning); //
+            playerController.manejarPulsacionEspacio(gameIsRunning); //
         }
     }, { passive: true });
 

--- a/playerController.js
+++ b/playerController.js
@@ -26,6 +26,7 @@ let playerIsAirborne = false;
 let doubleJumpAvailable = true; // Indica si el próximo salto en el aire puede ser un doble salto
 let jumpPressCount = 0;         // Rastrea las pulsaciones consecutivas de salto
 let isDashing = false;          // << NUEVO: Flag para el estado de Dash
+let ultimaPulsacionSalto = 0;    // Momento de la última pulsación de salto
 
 /** Inicializa o resetea el estado del jugador para una nueva partida. */
 export function initPlayerState() {
@@ -67,6 +68,28 @@ export function updatePlayerPhysics(deltaTime) {
         }
     }
     player.style.bottom = `${playerY}px`;
+}
+
+const VENTANA_DOBLE_TAP_MS = 250; // Tiempo máximo entre pulsaciones para doble tap
+
+/** Maneja la pulsación de espacio para salto o dash. */
+export function manejarPulsacionEspacio(isGameRunning) {
+    const ahora = Date.now();
+    const esDobleTap = (ahora - ultimaPulsacionSalto) <= VENTANA_DOBLE_TAP_MS;
+    ultimaPulsacionSalto = ahora;
+
+    if (esDobleTap && playerIsAirborne) {
+        if (_puedeUsarDash()) {
+            activateDash(COIN_TYPES.VIOLET);
+            return;
+        }
+    }
+    jump(isGameRunning);
+}
+
+function _puedeUsarDash() {
+    if (isDashing) return false;
+    return state.isUnlimitedMode() || state.hasPowerUp(COIN_TYPES.VIOLET);
 }
 
 /**


### PR DESCRIPTION
## Summary
- enable dash when double tapping space in midair
- update keyboard and touch handlers to use the new mechanic

## Testing
- `node --check playerController.js`
- `node --check inputManager.js`
- `python3 -m http.server` *(fails: command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_683f762c60888326b535e02314f19e7c