### PR TITLE
Modificar tiempo inicial del juego

### DIFF
--- a/config.js
+++ b/config.js
@@ -37,8 +37,8 @@ export const COIN_TYPES = Object.freeze({
     export const LEVEL_JUMP_MULTIPLIERS  = [1.0, 1.05, 1.0, 1.0, 1.0, 1.0];
     
     /* ---------- Tiempo, puntuación, ranking ---------- */
-    // Tiempo inicial reducido para partidas más rápidas
-    export const INITIAL_TIME_S   = 30; // Tiempo inicial en segundos
+    // Tiempo inicial levemente mayor
+    export const INITIAL_TIME_S   = 35; // Tiempo inicial en segundos
     export const MAX_TIME_CAP_S   = INITIAL_TIME_S + 60; // Límite máximo de tiempo acumulable
     export const OBSTACLE_HIT_PENALTY_S = 1;  // Segundos penalización por golpe
     export const COIN_SCORE_MULTIPLIER  = 5;  // Puntos base por moneda (multiplicado por combo actual)


### PR DESCRIPTION
## Summary
- ajustar la configuración de tiempo inicial a 35 segundos

## Testing
- `node --check config.js`
- `python3 -m http.server` (levantó el servidor correctamente)

------
https://chatgpt.com/codex/tasks/task_e_683fa64d9dec83268cd40a9af1528bd3