### PR TITLE
Mejora efecto visual y duración del Dash

### DIFF
--- a/config.js
+++ b/config.js
@@ -65,7 +65,7 @@ export const COIN_TYPES = Object.freeze({
     /* ---------- Configuración de Power-Ups ---------- */
     // Dash (Activado por Moneda Violeta)
     export const DASH_SPEED_BONUS = 800;     // Aumento instantáneo o velocidad fija extra (pixels/s)
-    export const DASH_DURATION_S = 0.25;   // Duración del Dash en segundos
+    export const DASH_DURATION_S = 0.5;    // Duración del Dash en segundos (más prolongado)
     export const DASH_INVULNERABLE = true; // Si el jugador es invulnerable durante el dash
     
     // Combo Aéreo (Activado por Moneda Blanca)

--- a/styles.css
+++ b/styles.css
@@ -228,23 +228,23 @@
   #player.dashing::after {
     content: "";
     position: absolute;
-    left: -40px;
-    top: 25%;
-    width: 30px;
-    height: 50%;
+    left: -60px;
+    top: 10%;
+    width: 50px;
+    height: 80%;
     background-image: repeating-linear-gradient(
         to bottom,
-        var(--color-violet) 0 2px,
-        transparent 2px 4px
+        var(--color-violet) 0 4px,
+        transparent 4px 8px
     );
-    animation: lineas-velocidad 0.2s linear infinite;
-    opacity: 0.7;
+    animation: lineas-velocidad 0.3s linear infinite;
+    opacity: 0.8;
     pointer-events: none;
   }
 
   @keyframes lineas-velocidad {
     from { transform: translateX(0); }
-    to { transform: translateX(-10px); }
+    to { transform: translateX(-20px); }
   }
   #player.jumping {
     box-shadow: 0 0 10px var(--color-player-shadow),


### PR DESCRIPTION
## Summary
- amplía el tiempo del Dash a medio segundo
- agranda las líneas de velocidad y hace más lento el movimiento

## Testing
- `node --check config.js`

------
https://chatgpt.com/codex/tasks/task_e_683faa3df7448326948d21fe0cc4450c